### PR TITLE
Cleanup of literal string constants from the service event handlers

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
@@ -19,6 +19,14 @@ package org.eclipse.kapua.event;
  * Each service that listens to service events must extend this class and add a list of constants
  * defining the class names of the event source services.
  *
+ * This base class defines all the applicable operation names. This is, these are the names of the methods
+ * that were invoked and that generated the events. The actual source service method names are used.
+ *
+ * Each service event object carries the name of the method that generated the event. This enables the event
+ * handler to correctly react to each event based on the exact operation type that was performed.
+ * It is imperative that the string literals are carefully aligned with the source service implementation.
+ * Each mistake here will result in the service event handler silently ignoring the events.
+ *
  * @since 1.0
  *
  */
@@ -26,33 +34,8 @@ public class ServiceEventConstants {
 
     protected ServiceEventConstants() {}
 
-    /**
-     * Service event operations.
-     *
-     * These are the names of the methods that were invoked and that generated the events. The actual source
-     * service method names are used.
-     *
-     * Each service event object carries the name of the method that generated the event. This enables the event
-     * handler to correctly react to each event based on the exact operation type that was performed.
-     * It is imperative that the string literals are carefully aligned with the source service implementation.
-     * Each mistake here will result in the service event handler silently ignoring the events.
-     */
     public static final String OPERATION_CREATE = "create";
     public static final String OPERATION_UPDATE = "update";
     public static final String OPERATION_DELETE = "delete";
-
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     *
-     * The event listening services must extend this class and list all the relevant event source service names.
-     */
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
@@ -14,8 +14,11 @@ package org.eclipse.kapua.event;
 /**
  * Service Event constants
  *
- * This is a helper class that contains the common constants that are used by all service event listeners
- * 
+ * This is a base class that contains the common constants that are used by all service event listeners
+ *
+ * Each service that listens to service events must extend this class and add a list of constants
+ * defining the class names of the event source services.
+ *
  * @since 1.0
  *
  */
@@ -37,5 +40,19 @@ public class ServiceEventConstants {
     public static final String OPERATION_CREATE = "create";
     public static final String OPERATION_UPDATE = "update";
     public static final String OPERATION_DELETE = "delete";
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     *
+     * The event listening services must extend this class and list all the relevant event source service names.
+     */
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventConstants.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.event;
+
+/**
+ * Service Event constants
+ *
+ * This is a helper class that contains the common constants that are used by all service event listeners
+ * 
+ * @since 1.0
+ *
+ */
+public class ServiceEventConstants {
+
+    protected ServiceEventConstants() {}
+
+    /**
+     * Service event operations.
+     *
+     * These are the names of the methods that were invoked and that generated the events. The actual source
+     * service method names are used.
+     *
+     * Each service event object carries the name of the method that generated the event. This enables the event
+     * handler to correctly react to each event based on the exact operation type that was performed.
+     * It is imperative that the string literals are carefully aligned with the source service implementation.
+     * Each mistake here will result in the service event handler silently ignoring the events.
+     */
+    public static final String OPERATION_CREATE = "create";
+    public static final String OPERATION_UPDATE = "update";
+    public static final String OPERATION_DELETE = "delete";
+
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class RegistryServiceConstants extends ServiceEventConstants {
+
+    private RegistryServiceConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+    public static final String TAG_SERVICE_NAME = "org.eclipse.kapua.service.tag.TagService";
+    public static final String GROUP_SERVICE_NAME = "org.eclipse.kapua.service.authorization.group.GroupService";
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.device.registry;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class RegistryServiceConstants extends ServiceEventConstants {
 
     private RegistryServiceConstants() {}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/RegistryServiceConstants.java
@@ -17,17 +17,7 @@ public final class RegistryServiceConstants extends ServiceEventConstants {
 
     private RegistryServiceConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
     public static final String TAG_SERVICE_NAME = "org.eclipse.kapua.service.tag.TagService";
     public static final String GROUP_SERVICE_NAME = "org.eclipse.kapua.service.authorization.group.GroupService";

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -205,6 +206,7 @@ public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableServic
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("DeviceConnectionService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("DeviceConnectionService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.registry.RegistryServiceConstants;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
@@ -45,9 +46,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.0
  */
 @KapuaProvider
-public class DeviceConnectionServiceImpl extends
-        //        AbstractKapuaConfigurableResourceLimitedService<DeviceConnection, DeviceConnectionCreator, DeviceConnectionService, DeviceConnectionListResult, DeviceConnectionQuery, DeviceConnectionFactory>
-        AbstractKapuaConfigurableService
+public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableService
         implements DeviceConnectionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnectionServiceImpl.class);
@@ -62,7 +61,6 @@ public class DeviceConnectionServiceImpl extends
     }
 
     public DeviceConnectionServiceImpl(DeviceEntityManagerFactory deviceEntityManagerFactory) {
-        //        super(DeviceConnectionService.class.getName(), DEVICE_CONNECTION_DOMAIN, deviceEntityManagerFactory, DeviceConnectionService.class, DeviceConnectionFactory.class);
         super(DeviceConnectionService.class.getName(), DEVICE_CONNECTION_DOMAIN, deviceEntityManagerFactory);
     }
 
@@ -209,7 +207,9 @@ public class DeviceConnectionServiceImpl extends
             LOGGER.warn("DeviceConnectionService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("DeviceConnectionService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (RegistryServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                RegistryServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteConnectionByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DevicePredicates;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.RegistryServiceConstants;
 import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,11 +179,15 @@ public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResource
             LOGGER.warn("DeviceRegistryService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("DeviceRegistryService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.authorization.group.GroupService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (RegistryServiceConstants.GROUP_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                RegistryServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             removeDevicesFromGroup(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
-        } else if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+        } else if (RegistryServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                RegistryServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteDeviceByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
-        } else if ("org.eclipse.kapua.service.tag.TagService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+        } else if (RegistryServiceConstants.TAG_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                RegistryServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             removeTagFromDevices(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -177,6 +178,7 @@ public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResource
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("DeviceRegistryService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("DeviceRegistryService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
@@ -17,16 +17,6 @@ public final class EndpointInfoServiceConstants extends ServiceEventConstants {
 
     private EndpointInfoServiceConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
 }

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.endpoint;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class EndpointInfoServiceConstants extends ServiceEventConstants {
 
     private EndpointInfoServiceConstants() {}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoServiceConstants.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class EndpointInfoServiceConstants extends ServiceEventConstants {
+
+    private EndpointInfoServiceConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -249,6 +250,7 @@ public class EndpointInfoServiceImpl
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("EndpointInfoService: received null kapua event from account");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("EndpointInfoService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -40,6 +40,7 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoPredicates;
 import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+import org.eclipse.kapua.service.endpoint.EndpointInfoServiceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,7 +251,9 @@ public class EndpointInfoServiceImpl
             LOGGER.warn("EndpointInfoService: received null kapua event from account");
         }
         LOGGER.info("EndpointInfoService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (EndpointInfoServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                EndpointInfoServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteEndpointsByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
@@ -18,16 +18,6 @@ public final class JobServiceConstants extends ServiceEventConstants {
     private JobServiceConstants() {
     }
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.job;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class JobServiceConstants extends ServiceEventConstants {
 
     private JobServiceConstants() {

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/JobServiceConstants.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class JobServiceConstants extends ServiceEventConstants {
+
+    private JobServiceConstants() {
+    }
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+}

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.kapua.service.job.JobListResult;
 import org.eclipse.kapua.service.job.JobPredicates;
 import org.eclipse.kapua.service.job.JobQuery;
 import org.eclipse.kapua.service.job.JobService;
+import org.eclipse.kapua.service.job.JobServiceConstants;
 import org.eclipse.kapua.service.scheduler.trigger.Trigger;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerListResult;
@@ -235,7 +236,9 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
             LOGGER.warn("JobService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("JobService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (JobServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                JobServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteJobsByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.RaiseServiceEvent;
@@ -234,6 +235,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("JobService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("JobService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
@@ -17,16 +17,6 @@ public final class SchedulerServiceConstants extends ServiceEventConstants {
 
     private SchedulerServiceConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String JOB_SERVICE_NAME = "org.eclipse.kapua.service.job.JobService";
 }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class SchedulerServiceConstants extends ServiceEventConstants {
+
+    private SchedulerServiceConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String JOB_SERVICE_NAME = "org.eclipse.kapua.service.job.JobService";
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.scheduler;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class SchedulerServiceConstants extends ServiceEventConstants {
 
     private SchedulerServiceConstants() {}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -295,8 +296,8 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
     @ListenServiceEvent(fromAddress = "job")
     public void onKapuaJobEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
-            LOGGER.warn("TriggerService: received null kapua event from job");
-            return;
+            LOGGER.warn("TriggerService: Service bus error. Received null ServiceEvent.");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.trace("TriggerService: received kapua {} event from {}, context {}",
                 kapuaEvent.getOperation(), kapuaEvent.getService(), kapuaEvent.getContextId());

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.scheduler.SchedulerServiceConstants;
 import org.eclipse.kapua.service.scheduler.trigger.Trigger;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerCreator;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
@@ -299,7 +300,9 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
         }
         LOGGER.trace("TriggerService: received kapua {} event from {}, context {}",
                 kapuaEvent.getOperation(), kapuaEvent.getService(), kapuaEvent.getContextId());
-        if ("org.eclipse.kapua.service.job.JobService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (SchedulerServiceConstants.JOB_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                SchedulerServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteTriggersByJobId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.authentication;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class AuthenticationServicesConstants extends ServiceEventConstants {
 
     private AuthenticationServicesConstants() {}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class AuthenticationServicesConstants extends ServiceEventConstants {
+
+    private AuthenticationServicesConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+    public static final String USER_SERVICE_NAME = "org.eclipse.kapua.service.user.UserService";
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServicesConstants.java
@@ -17,17 +17,7 @@ public final class AuthenticationServicesConstants extends ServiceEventConstants
 
     private AuthenticationServicesConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
     public static final String USER_SERVICE_NAME = "org.eclipse.kapua.service.user.UserService";
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
+import org.eclipse.kapua.service.authentication.AuthenticationServicesConstants;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
 import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
@@ -377,9 +378,12 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
             LOGGER.warn("CredentialService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("CredentialService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.user.UserService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (AuthenticationServicesConstants.USER_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthenticationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteCredentialByUserId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
-        } else if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+        } else if (AuthenticationServicesConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthenticationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteCredentialByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -376,6 +377,7 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("CredentialService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("CredentialService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.AuthenticationServicesConstants;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.authentication.token.AccessTokenCreator;
 import org.eclipse.kapua.service.authentication.token.AccessTokenListResult;
@@ -242,9 +243,12 @@ public class AccessTokenServiceImpl extends AbstractKapuaService implements Acce
         }
 
         LOGGER.info("AccessTokenService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.user.UserService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (AuthenticationServicesConstants.USER_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthenticationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteAccessTokenByUserId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
-        } else if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+        } else if (AuthenticationServicesConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthenticationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteAccessTokenByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -240,8 +241,8 @@ public class AccessTokenServiceImpl extends AbstractKapuaService implements Acce
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("AccessTokenService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
-
         LOGGER.info("AccessTokenService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 
         if (AuthenticationServicesConstants.USER_SERVICE_NAME.equals(kapuaEvent.getService()) &&

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
@@ -17,17 +17,7 @@ public final class AuthorizationServicesConstants extends ServiceEventConstants 
 
     private AuthorizationServicesConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
     public static final String USER_SERVICE_NAME = "org.eclipse.kapua.service.user.UserService";
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class AuthorizationServicesConstants extends ServiceEventConstants {
+
+    private AuthorizationServicesConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+    public static final String USER_SERVICE_NAME = "org.eclipse.kapua.service.user.UserService";
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServicesConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.authorization;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class AuthorizationServicesConstants extends ServiceEventConstants {
 
     private AuthorizationServicesConstants() {}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.AuthorizationServicesConstants;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
 import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
@@ -221,9 +222,12 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
             LOGGER.warn("AccessInfoService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("AccessInfoService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.user.UserService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (AuthorizationServicesConstants.USER_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthorizationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteAccessInfoByUserId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
-        } else if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+        } else if (AuthorizationServicesConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthorizationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteAccessInfoByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -220,6 +221,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("AccessInfoService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("AccessInfoService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.RaiseServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -207,6 +208,7 @@ public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedSe
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("GroupService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("GroupService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.AuthorizationServicesConstants;
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.authorization.group.GroupCreator;
 import org.eclipse.kapua.service.authorization.group.GroupFactory;
@@ -207,9 +208,10 @@ public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedSe
         if (kapuaEvent == null) {
             LOGGER.warn("GroupService: Service bus error. Received null ServiceEvent");
         }
-
         LOGGER.info("GroupService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (AuthorizationServicesConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthorizationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteGroupByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.AuthorizationServicesConstants;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
@@ -242,9 +243,10 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
             //service bus error. Throw some exception?
             LOGGER.warn("RoleService: Service bus error. Received null ServiceEvent");
         }
-
         LOGGER.info("RoleService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (AuthorizationServicesConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                AuthorizationServicesConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteRoleByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -240,8 +241,8 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
     @ListenServiceEvent(fromAddress="account")
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
-            //service bus error. Throw some exception?
             LOGGER.warn("RoleService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("RoleService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.tag;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class TagServiceConstants extends ServiceEventConstants {
 
     private TagServiceConstants() {}

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.tag;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class TagServiceConstants extends ServiceEventConstants {
+
+    private TagServiceConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+}

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/TagServiceConstants.java
@@ -17,16 +17,6 @@ public final class TagServiceConstants extends ServiceEventConstants {
 
     private TagServiceConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
 }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.kapua.service.tag.TagListResult;
 import org.eclipse.kapua.service.tag.TagPredicates;
 import org.eclipse.kapua.service.tag.TagQuery;
 import org.eclipse.kapua.service.tag.TagService;
+import org.eclipse.kapua.service.tag.TagServiceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,7 +208,9 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
             LOGGER.warn("TagService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("TagService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (TagServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                TagServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteTagByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.RaiseServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -206,6 +207,7 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("TagService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("TagService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
@@ -13,6 +13,19 @@ package org.eclipse.kapua.service.user;
 
 import org.eclipse.kapua.event.ServiceEventConstants;
 
+/**
+ * Service event sources.
+ *
+ * These are the class names of the services that generate the events. All the relevant source service names must
+ * be listed.
+ *
+ * Each event object carries the class name of the generating service. This makes it possible to handle each
+ * event based on the source service.
+ * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+ * name constant here will cause the handler to silently ignore the relevant service events.
+ *
+ * The event listening services must extend this class and list all the relevant event source service names.
+ */
 public final class UserServiceConstants extends ServiceEventConstants {
 
     private UserServiceConstants() {}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
@@ -17,16 +17,6 @@ public final class UserServiceConstants extends ServiceEventConstants {
 
     private UserServiceConstants() {}
 
-    /**
-     * Service event sources.
-     *
-     * These are the class names of the services that generate the events. All the relevant source service names must
-     * be listed here.
-     *
-     * Each event object carries the class name of the generating service. This makes it possible to handle each
-     * event based on the source service.
-     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
-     * name constant here will cause the handler to silently ignore the relevant service events.
-     */
+    // Service event source class names
     public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/UserServiceConstants.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user;
+
+import org.eclipse.kapua.event.ServiceEventConstants;
+
+public final class UserServiceConstants extends ServiceEventConstants {
+
+    private UserServiceConstants() {}
+
+    /**
+     * Service event sources.
+     *
+     * These are the class names of the services that generate the events. All the relevant source service names must
+     * be listed here.
+     *
+     * Each event object carries the class name of the generating service. This makes it possible to handle each
+     * event based on the source service.
+     * It is crucial that the constants defined below match the exact source service class names. A mistake in a class
+     * name constant here will cause the handler to silently ignore the relevant service events.
+     */
+    public static final String ACCOUNT_SERVICE_NAME = "org.eclipse.kapua.service.account.AccountService";
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.RaiseServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -278,6 +279,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
     public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
         if (kapuaEvent == null) {
             LOGGER.warn("UserService: Service bus error. Received null ServiceEvent");
+            throw new ServiceEventBusException("Service bus error. Received null ServiceEvent.");
         }
         LOGGER.info("UserService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
 

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -41,6 +41,7 @@ import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserPredicates;
 import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserService;
+import org.eclipse.kapua.service.user.UserServiceConstants;
 import org.eclipse.kapua.service.user.UserStatus;
 import org.eclipse.kapua.service.user.UserType;
 import org.slf4j.Logger;
@@ -279,7 +280,9 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
             LOGGER.warn("UserService: Service bus error. Received null ServiceEvent");
         }
         LOGGER.info("UserService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
-        if ("org.eclipse.kapua.service.account.AccountService".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
+
+        if (UserServiceConstants.ACCOUNT_SERVICE_NAME.equals(kapuaEvent.getService()) &&
+                UserServiceConstants.OPERATION_DELETE.equals(kapuaEvent.getOperation())) {
             deleteUserByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }


### PR DESCRIPTION
Moved the literal string constants to separate helper classes.

**Description of the solution adopted**
The base class _ServiceEventConstants_ contains the common constants that are used by all listening services.
Each listening service must extend this class and add its own constants, as needed. Generally, these are the class names of the services, whose events it listens to.
